### PR TITLE
Fix for file and code blocks

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -96,7 +96,8 @@ class helper_plugin_orphanswanted extends DokuWiki_Plugin {
         foreach( array(
                   '/<nowiki>.*?<\/nowiki>/',
                   '/%%.*?%%/',
-                  '/<code .*?>.*?<\/code>/'
+                  '@<code[^>]*?>.*?<\/code>@siu',
+                  '@<file[^>]*?>.*?<\/file>@siu'
         )
         as $ignored )
         {


### PR DESCRIPTION
<file> and <code> blocks coud contain [[]] characters that break the dokuwiki link structure. Added code to ignore contents of these blocks.
