### PR TITLE
Added a event to allow 3rd party plugins to handle custom link syntax

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -31,6 +31,12 @@ class helper_plugin_orphanswanted extends DokuWiki_Plugin {
         //	orph_Check_InternalLinks(&$data,$base,$file,$type,$lvl,$opts);
         $this->orph_Check_InternalLinks($data,$base,$file,$type,$lvl,$opts);
 
+        $eventData = array(
+            'data' => &$data,
+            'file' => $file
+        );
+        trigger_event('PLUGIN_ORPHANS_WANTED_PROCESS_PAGE', $eventData);
+
         // get id of this file
         $id = pathID($file);
 


### PR DESCRIPTION
This patch allows a 3rd party plugin to handle a page process and search for links itself.

The event is called: PLUGIN_ORPHANS_WANTED_PROCESS_PAGE

I want to use this in the include plugin. The goal is that included pages are not treated as orphans.
