### PR TITLE
Strip parameters from found links

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -124,6 +124,9 @@ class helper_plugin_orphanswanted extends DokuWiki_Plugin {
             and ! preg_match('<'.PREG_PATTERN_VALID_EMAIL.'>',$link) // E-Mail (pattern above is defined in inc/mail.php)
             and ! preg_match('!^#.+!',$link) // inside page link (html anchor)
             ) {
+                # remove parameters
+                $link = preg_replace('/\?.*/', '', $link) . "\n";
+
                 $pageExists = false;
                 resolve_pageid($currentNS, $link, $pageExists );
                 if ($conf['allowdebug']) echo sprintf("---- link='%s' %s ", $link, $pageExists?'EXISTS':'MISS');


### PR DESCRIPTION
Hello,

In my site I use a few links with url parameters, for example for exporting contents to pdf (https://www.dokuwiki.org/plugin:dw2pdf).
OrphansWanted treated them as dead links, so I make a simple fix for that.

So if you like it you might want to merge it with master branch.

Best regards,