### PR TITLE
Added ignored patterns and fixed case-insensitive patterns

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -99,12 +99,17 @@ class helper_plugin_orphanswanted extends DokuWiki_Plugin {
         // echo "  <!-- checking file: $file -->\n";
         $body = @file_get_contents($conf['datadir'] . $file);
 
-        // ignores entries in <nowiki>, %%, <code> and emails with @
+        // ignores entries in blocks that ignore links
         foreach( array(
-                  '/<nowiki>.*?<\/nowiki>/',
-                  '/%%.*?%%/',
-                  '@<code[^>]*?>.*?<\/code>@siu',
-                  '@<file[^>]*?>.*?<\/file>@siu'
+                  '@<nowiki>.*?<\/nowiki>@su',
+                  '@%%.*?%%@su',
+                  '@<php>.*?</php>@su',
+                  '@<PHP>.*?</PHP>@su',
+                  '@<html>.*?</html>@su',
+                  '@<HTML>.*?</HTML>@su',
+                  '@\n( {2,}|\t)[^\*\- ].*?\n@su',
+                  '@<code[^>]*?>.*?<\/code>@su',
+                  '@<file[^>]*?>.*?<\/file>@su'
         )
         as $ignored )
         {

--- a/helper.php
+++ b/helper.php
@@ -107,7 +107,7 @@ class helper_plugin_orphanswanted extends DokuWiki_Plugin {
                   '@<PHP>.*?</PHP>@su',
                   '@<html>.*?</html>@su',
                   '@<HTML>.*?</HTML>@su',
-                  '@\n( {2,}|\t)[^\*\- ].*?\n@su',
+                  '@^( {2,}|\t)[^\*\- ].*?$@mu',
                   '@<code[^>]*?>.*?<\/code>@su',
                   '@<file[^>]*?>.*?<\/file>@su'
         )


### PR DESCRIPTION
This removes the case-insensitivity from `<code>` and `<file>`.
Both unformatted tags (`<nowiki>` and `%%`) get updated to unicode detection.
New support for `<php>`, `<PHP>`, `<html>`, `<HTML>` and space / tab intended blocks.